### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server for [Penrose](https://penrose.cs.cmu.edu/) - Create beautiful mathematical diagrams through natural language.
 
+<a href="https://glama.ai/mcp/servers/bc2re1p5ho"><img width="380" height="200" src="https://glama.ai/mcp/servers/bc2re1p5ho/badge" alt="Penrose Server MCP server" /></a>
+
 ## Overview
 
 This MCP server provides tools and resources for creating mathematical diagrams using Penrose's domain-specific languages:


### PR DESCRIPTION
This PR adds a badge for the [Penrose MCP Server](https://glama.ai/mcp/servers/bc2re1p5ho) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/bc2re1p5ho"><img width="380" height="200" src="https://glama.ai/mcp/servers/bc2re1p5ho/badge" alt="Penrose Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.